### PR TITLE
fix: Rework method to embed plain text files to use the original filename for the embedded file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .DS_Store
 .vscode
 .resumes/*
+.embedded_resumes/*

--- a/llm.py
+++ b/llm.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 from langchain_community.llms import Ollama
 from langchain_core.prompts import ChatPromptTemplate
@@ -22,32 +23,6 @@ prompt = ChatPromptTemplate.from_messages([(
 ])
 
 # model = SentenceTransformer('all-MiniLM-L6-v2nomic-embed-text')
-
-ollama_emb = OllamaEmbeddings(model='nomic-embed-text', base_url="https://7fb4-35-187-254-204.ngrok-free.app")
-
-llm = Ollama(model="llama3", base_url="https://7fb4-35-187-254-204.ngrok-free.app")
+llm = Ollama(model="llama3", base_url=os.environ["OLLAMA_HOST"])
 
 chain = prompt | llm | StrOutputParser()
-
-
-import os
-
-def filesByPattern(directory, matchFunc):
-  for path, dirs, files in os.walk(directory):
-    return files
-
-
-if __name__ == '__main__':
-    certainFolder = './resumes'
-    files = []
-    all_files = filesByPattern(certainFolder, lambda fn: fn.endswith('.txt'))
-    for file in all_files:
-        if '.txt' not in file or 'requirements.txt' == file:
-           continue
-        print(file)
-        with open(file, 'r+', encoding='utf8') as f:
-            files.append(f.read())
-    embeded_docs = ollama_emb.embed_documents(files)
-    for i, embed in enumerate(embeded_docs):
-        with open(f"output_embed{i}.txt", 'w+') as f_w:
-            f_w.write(str(embed))

--- a/tools/embedded_files_generator.py
+++ b/tools/embedded_files_generator.py
@@ -1,0 +1,45 @@
+import os
+import re
+from langchain_community.embeddings import OllamaEmbeddings
+
+ollama_emb = OllamaEmbeddings(model="nomic-embed-text", base_url=os.environ["OLLAMA_HOST"])
+
+def getFilesByPattern(dir, matchFunc):
+  """
+  Retrieve all files from a folder by filtering them using a specific pattern.
+
+  Parameters:
+    dir: str
+    matchFunc: function
+  """
+
+  txt_files = []
+  for file in os.listdir(dir):
+    if matchFunc(file):
+      txt_files.append(file)
+
+  return txt_files
+
+
+def embedFiles():
+  """
+  Embed the plain text files from a folder using Ollama.
+  """
+
+  EMBEDDED_RESUMES_FOLDER = "../.embedded_resumes"
+  EXTENSION_LENGTH = 4
+  RESUMES_FOLDER = "../.resumes"
+  
+  resume_files = getFilesByPattern(RESUMES_FOLDER, lambda file: file.endswith(".txt"))
+
+  for resume_file in resume_files:
+    embedded_file_content = ''
+
+    with open(f"{RESUMES_FOLDER}/{resume_file}", 'r', encoding='utf-8') as rf:
+      resume_file_content = rf.read()
+      embedded_file_content = ollama_emb.embed_query(resume_file_content)
+
+    with open(f"{EMBEDDED_RESUMES_FOLDER}/{resume_file[:-EXTENSION_LENGTH]}_embedded.txt", "w") as rfe:
+      rfe.write(str(embedded_file_content))
+
+embedFiles()


### PR DESCRIPTION
## Description & motivation
[Linked Issue](https://github.com/orgs/Apex-CS/projects/19?pane=issue&itemId=81396964&issue=Apex-CS%7CEmployee-Assistant%7C7)
Rework the method to embed plain text files to embed files so the original filename is also used for the embedded file.

## Screenshots:
![image](https://github.com/user-attachments/assets/3a22c6f1-a0db-48f8-b16e-5bcff5d608a9)

## Checklist:
- [X] My pull request represents one logical piece of work.
- [X] My commits are related to the pull request and look clean.
- [X] My code follows the style guide.
- [X] I have added appropriate tests and documentation.